### PR TITLE
add support for streaming uploads

### DIFF
--- a/pycurl_requests/tests/test_streaming.py
+++ b/pycurl_requests/tests/test_streaming.py
@@ -1,0 +1,38 @@
+import io
+from pycurl_requests import requests
+from pycurl_requests.tests.utils import *
+
+
+def test_streaming_upload_from_file(http_server):
+    f = io.BytesIO(test_data)
+    response = requests.post(http_server.base_url + '/stream', data=f)
+    assert response.status_code == 200
+
+
+def data_generator(data: bytes, chunk_size: int):
+    i = 0
+    while True:
+        chunk = data[chunk_size * i: chunk_size * (i + 1)]
+        if len(chunk) == 0:
+            break
+        yield chunk
+        i += 1
+
+
+def test_streaming_upload_form_iterable(http_server):
+    response = requests.post(http_server.base_url + '/stream', data=data_generator(test_data, 123))
+    assert response.status_code == 200
+
+
+def test_streaming_upload_form_iterable_with_known_length(http_server):
+    class FixedLengthIterable:
+        data = test_data
+
+        def __len__(self):
+            return len(self.data)
+
+        def __iter__(self):
+            return data_generator(data=self.data, chunk_size=123)
+
+    response = requests.post(http_server.base_url + '/stream_no_chunked', data=FixedLengthIterable())
+    assert response.status_code == 200


### PR DESCRIPTION
Hi all,

I happened to use streaming uploads with requests and curl a lot (using both individually but not in combination). So I felt like adding support for the data access protocols that requests supports to this cool project would a useful contribution.
The PR isn't ready yet and I hope to finish it soon. There are still a few sections that I have marked with TODO comments. I'm also not completely sure how the Content-Length header and libcurl's `INFILESIZE_LARGE` interact. Would be nice to have your opinion on this PR.

Fabian